### PR TITLE
added necessary dependency for Ubuntu 20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The latest Windows release can be found [here](https://getgammy.com/downloads.ht
 
 On Debian-based distros:
 ```
-sudo apt install git build-essential libgl1-mesa-dev qt5-default
+sudo apt install git build-essential libgl1-mesa-dev qt5-default libxxf86vm-dev
 ```
 
 Additionally, the "qt5ct" plugin is recommended if you are running a DE/WM without Qt integration (e.g. GNOME):


### PR DESCRIPTION
This is a missing dependency (package) on Ubuntu 20.04, without which `make` will fail (see below for reference). Package is also available for install on previous Ubuntu/Debian releases.

Without `libxxf86vm-dev` installed:

```
$ make
/usr/lib/qt5/bin/uic src/mainwindow.ui -o src/ui_mainwindow.h
/usr/lib/qt5/bin/uic src/tempscheduler.ui -o src/ui_tempscheduler.h
g++ -c -pipe -O3 -std=gnu++1z -Wall -W -D_REENTRANT -fPIC -DQT_DEPRECATED_WARNINGS -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I. -Iincludes -isystem /usr/include/x86_64-linux-gnu/qt5 -isystem /usr/include/x86_64-linux-gnu/qt5/QtWidgets -isystem /usr/include/x86_64-linux-gnu/qt5/QtGui -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore -Ires/tmp -Isrc -I/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++ -o res/tmp/main.o src/main.cpp
g++ -c -pipe -O3 -std=gnu++1z -Wall -W -D_REENTRANT -fPIC -DQT_DEPRECATED_WARNINGS -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I. -Iincludes -isystem /usr/include/x86_64-linux-gnu/qt5 -isystem /usr/include/x86_64-linux-gnu/qt5/QtWidgets -isystem /usr/include/x86_64-linux-gnu/qt5/QtGui -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore -Ires/tmp -Isrc -I/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++ -o res/tmp/mainwindow.o src/mainwindow.cpp
g++ -c -pipe -O3 -std=gnu++1z -Wall -W -D_REENTRANT -fPIC -DQT_DEPRECATED_WARNINGS -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I. -Iincludes -isystem /usr/include/x86_64-linux-gnu/qt5 -isystem /usr/include/x86_64-linux-gnu/qt5/QtWidgets -isystem /usr/include/x86_64-linux-gnu/qt5/QtGui -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore -Ires/tmp -Isrc -I/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++ -o res/tmp/utils.o src/utils.cpp
src/utils.cpp: In function ‘double easeInOutQuad(double, double, double, double)’:
src/utils.cpp:78:21: warning: operation on ‘t’ may be undefined [-Wsequence-point]
   78 |   return -c / 2 * ((--t) * (t - 2) - 1) + b;
      |                    ~^~~~
src/utils.cpp:78:21: warning: operation on ‘t’ may be undefined [-Wsequence-point]
g++ -c -pipe -O3 -std=gnu++1z -Wall -W -D_REENTRANT -fPIC -DQT_DEPRECATED_WARNINGS -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I. -Iincludes -isystem /usr/include/x86_64-linux-gnu/qt5 -isystem /usr/include/x86_64-linux-gnu/qt5/QtWidgets -isystem /usr/include/x86_64-linux-gnu/qt5/QtGui -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore -Ires/tmp -Isrc -I/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++ -o res/tmp/tempscheduler.o src/tempscheduler.cpp
g++ -c -pipe -O3 -std=gnu++1z -Wall -W -D_REENTRANT -fPIC -DQT_DEPRECATED_WARNINGS -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I. -Iincludes -isystem /usr/include/x86_64-linux-gnu/qt5 -isystem /usr/include/x86_64-linux-gnu/qt5/QtWidgets -isystem /usr/include/x86_64-linux-gnu/qt5/QtGui -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore -Ires/tmp -Isrc -I/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++ -o res/tmp/cfg.o src/cfg.cpp
g++ -c -pipe -O3 -std=gnu++1z -Wall -W -D_REENTRANT -fPIC -DQT_DEPRECATED_WARNINGS -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I. -Iincludes -isystem /usr/include/x86_64-linux-gnu/qt5 -isystem /usr/include/x86_64-linux-gnu/qt5/QtWidgets -isystem /usr/include/x86_64-linux-gnu/qt5/QtGui -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore -Ires/tmp -Isrc -I/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++ -o res/tmp/RangeSlider.o src/RangeSlider.cpp
g++ -c -pipe -O3 -std=gnu++1z -Wall -W -D_REENTRANT -fPIC -DQT_DEPRECATED_WARNINGS -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I. -Iincludes -isystem /usr/include/x86_64-linux-gnu/qt5 -isystem /usr/include/x86_64-linux-gnu/qt5/QtWidgets -isystem /usr/include/x86_64-linux-gnu/qt5/QtGui -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore -Ires/tmp -Isrc -I/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++ -o res/tmp/x11.o src/x11.cpp
src/x11.cpp:10:10: fatal error: X11/extensions/xf86vmode.h: No such file or directory
   10 | #include <X11/extensions/xf86vmode.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make: *** [Makefile:622: res/tmp/x11.o] Error 1
```

With `libxxf86vm-dev` installed:

```
$ make
g++ -c -pipe -O3 -std=gnu++1z -Wall -W -D_REENTRANT -fPIC -DQT_DEPRECATED_WARNINGS -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I. -Iincludes -isystem /usr/include/x86_64-linux-gnu/qt5 -isystem /usr/include/x86_64-linux-gnu/qt5/QtWidgets -isystem /usr/include/x86_64-linux-gnu/qt5/QtGui -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore -Ires/tmp -Isrc -I/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++ -o res/tmp/x11.o src/x11.cpp
/usr/lib/qt5/bin/rcc -name res res.qrc -o res/qrc_res.cpp
g++ -c -pipe -O3 -std=gnu++1z -Wall -W -D_REENTRANT -fPIC -DQT_DEPRECATED_WARNINGS -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I. -Iincludes -isystem /usr/include/x86_64-linux-gnu/qt5 -isystem /usr/include/x86_64-linux-gnu/qt5/QtWidgets -isystem /usr/include/x86_64-linux-gnu/qt5/QtGui -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore -Ires/tmp -Isrc -I/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++ -o res/tmp/qrc_res.o res/qrc_res.cpp
g++ -pipe -O3 -std=gnu++1z -Wall -W -dM -E -o res/tmp/moc_predefs.h /usr/lib/x86_64-linux-gnu/qt5/mkspecs/features/data/dummy.cpp
/usr/lib/qt5/bin/moc -DQT_DEPRECATED_WARNINGS -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB --include /home/ahodzic/code/gammy/res/tmp/moc_predefs.h -I/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++ -I/home/ahodzic/code/gammy -I/home/ahodzic/code/gammy/includes -I/usr/include/x86_64-linux-gnu/qt5 -I/usr/include/x86_64-linux-gnu/qt5/QtWidgets -I/usr/include/x86_64-linux-gnu/qt5/QtGui -I/usr/include/x86_64-linux-gnu/qt5/QtCore -I/usr/include/c++/9 -I/usr/include/x86_64-linux-gnu/c++/9 -I/usr/include/c++/9/backward -I/usr/lib/gcc/x86_64-linux-gnu/9/include -I/usr/local/include -I/usr/lib/gcc/x86_64-linux-gnu/9/include-fixed -I/usr/include/x86_64-linux-gnu -I/usr/include src/mainwindow.h -o res/tmp/moc_mainwindow.cpp
g++ -c -pipe -O3 -std=gnu++1z -Wall -W -D_REENTRANT -fPIC -DQT_DEPRECATED_WARNINGS -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I. -Iincludes -isystem /usr/include/x86_64-linux-gnu/qt5 -isystem /usr/include/x86_64-linux-gnu/qt5/QtWidgets -isystem /usr/include/x86_64-linux-gnu/qt5/QtGui -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore -Ires/tmp -Isrc -I/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++ -o res/tmp/moc_mainwindow.o res/tmp/moc_mainwindow.cpp
/usr/lib/qt5/bin/moc -DQT_DEPRECATED_WARNINGS -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB --include /home/ahodzic/code/gammy/res/tmp/moc_predefs.h -I/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++ -I/home/ahodzic/code/gammy -I/home/ahodzic/code/gammy/includes -I/usr/include/x86_64-linux-gnu/qt5 -I/usr/include/x86_64-linux-gnu/qt5/QtWidgets -I/usr/include/x86_64-linux-gnu/qt5/QtGui -I/usr/include/x86_64-linux-gnu/qt5/QtCore -I/usr/include/c++/9 -I/usr/include/x86_64-linux-gnu/c++/9 -I/usr/include/c++/9/backward -I/usr/lib/gcc/x86_64-linux-gnu/9/include -I/usr/local/include -I/usr/lib/gcc/x86_64-linux-gnu/9/include-fixed -I/usr/include/x86_64-linux-gnu -I/usr/include src/tempscheduler.h -o res/tmp/moc_tempscheduler.cpp
g++ -c -pipe -O3 -std=gnu++1z -Wall -W -D_REENTRANT -fPIC -DQT_DEPRECATED_WARNINGS -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I. -Iincludes -isystem /usr/include/x86_64-linux-gnu/qt5 -isystem /usr/include/x86_64-linux-gnu/qt5/QtWidgets -isystem /usr/include/x86_64-linux-gnu/qt5/QtGui -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore -Ires/tmp -Isrc -I/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++ -o res/tmp/moc_tempscheduler.o res/tmp/moc_tempscheduler.cpp
/usr/lib/qt5/bin/moc -DQT_DEPRECATED_WARNINGS -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB --include /home/ahodzic/code/gammy/res/tmp/moc_predefs.h -I/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++ -I/home/ahodzic/code/gammy -I/home/ahodzic/code/gammy/includes -I/usr/include/x86_64-linux-gnu/qt5 -I/usr/include/x86_64-linux-gnu/qt5/QtWidgets -I/usr/include/x86_64-linux-gnu/qt5/QtGui -I/usr/include/x86_64-linux-gnu/qt5/QtCore -I/usr/include/c++/9 -I/usr/include/x86_64-linux-gnu/c++/9 -I/usr/include/c++/9/backward -I/usr/lib/gcc/x86_64-linux-gnu/9/include -I/usr/local/include -I/usr/lib/gcc/x86_64-linux-gnu/9/include-fixed -I/usr/include/x86_64-linux-gnu -I/usr/include src/RangeSlider.h -o res/tmp/moc_RangeSlider.cpp
g++ -c -pipe -O3 -std=gnu++1z -Wall -W -D_REENTRANT -fPIC -DQT_DEPRECATED_WARNINGS -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I. -Iincludes -isystem /usr/include/x86_64-linux-gnu/qt5 -isystem /usr/include/x86_64-linux-gnu/qt5/QtWidgets -isystem /usr/include/x86_64-linux-gnu/qt5/QtGui -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore -Ires/tmp -Isrc -I/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++ -o res/tmp/moc_RangeSlider.o res/tmp/moc_RangeSlider.cpp
g++ -Wl,-O1 -o gammy res/tmp/main.o res/tmp/mainwindow.o res/tmp/utils.o res/tmp/tempscheduler.o res/tmp/cfg.o res/tmp/RangeSlider.o res/tmp/x11.o res/tmp/qrc_res.o res/tmp/moc_mainwindow.o res/tmp/moc_tempscheduler.o res/tmp/moc_RangeSlider.o   -lX11 -lXxf86vm /usr/lib/x86_64-linux-gnu/libQt5Widgets.so /usr/lib/x86_64-linux-gnu/libQt5Gui.so /usr/lib/x86_64-linux-gnu/libQt5Core.so /usr/lib/x86_64-linux-gnu/libGL.so -lpthread   
```