### PR TITLE
Fixinf Compile Errors

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -8,6 +8,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <stdio.h>
+#include <stdlib.h>
 
 int    calcBrightness(uint8_t *buf, uint64_t buf_sz, int bytes_per_pixel, int stride);
 double lerp(double x, double a, double b);


### PR DESCRIPTION
While compiling gammy spawns :
 ```src/utils.h:17:29: error: ‘size_t’ has not been declared```
I have added necessary header files to fix the problem and it compiles just fine.
(Tested on Gentoo with gcc-11.2.0)